### PR TITLE
initial commit of PyPI publishing workflow

### DIFF
--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -1,0 +1,41 @@
+# This workflow will publish releases to https://pypi.org/project/nuclear-rose/
+
+name: PyPI publisher
+
+on:
+  release:
+    types: [published]
+  
+jobs:
+  pypi-publish:
+    name: Build and upload release to PyPI
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/project/nuclear-rose/
+    permissions:
+      id-token: write  
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up Python
+      uses: actions/setup-python@v4
+      with:
+        python-version: "3.x"
+    - name: Install pypa/build
+      run: >-
+        python3 -m
+        pip install
+        build
+        --user
+    - name: Build a binary wheel and a source tarball
+      run: >-
+        python3 -m
+        build
+        --sdist
+        --wheel
+        --outdir dist/
+        .
+    - name: Publish distribution 📦 to PyPI
+      uses: pypa/gh-action-pypi-publish@release/v1
+      with:
+        password: ${{ secrets.PYPI_ACCESS_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ tests/__pycache__/
 tests/__pycache__/test_interactions.cpython-310.pyc
 tests/__pycache__/test_schroedinger_equation.cpython-310.pyc
 site/
+__version__.py

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=61.0"]
+requires = ["setuptools>=61.0", "setuptools_scm[toml]>=6.2"]
 build-backend = "setuptools.build_meta"
 
 [project]
@@ -20,5 +20,7 @@ classifiers = [
 ]
 
 [tool.setuptools.dynamic]
-version = {attr = "rose.__version__"}
 dependencies = {file = ["requirements.txt"]}
+
+[tool.setuptools_scm]
+write_to = "src/rose/__version__.py"

--- a/src/rose/__init__.py
+++ b/src/rose/__init__.py
@@ -11,5 +11,4 @@ from .basis import CustomBasis, RelativeBasis
 from .koning_delaroche import KoningDelaroche, EnergizedKoningDelaroche
 from .spin_orbit import SpinOrbitTerm
 
-
-__version__ = '0.9.3'
+from .__version__ import __version__


### PR DESCRIPTION
This is a GH workflow that publishes a new release to the PyPI every time a release is published on GH. I adapted it from [another library](https://github.com/beykyle/lagrange_rmatrix) I work on, and it was originally adapted from [here](https://packaging.python.org/en/latest/guides/publishing-package-distribution-releases-using-github-actions-ci-cd-workflows/).

To get this working, the following steps need to be taken by an admin of the PyPI project:
1.  add this github repo as a [trusted publisher on the PyPI](https://docs.pypi.org/trusted-publishers/adding-a-publisher/)
2. [create a PyPI API token](https://pypi.org/help/#apitoken) and add it as a [github secret to the ROSE](https://docs.github.com/en/actions/security-guides/encrypted-secrets) , under the name `PYPI_ACCESS_TOKEN`

That's it!

Note: this does not update the semantic version number in `pyproject.toml` - which is the one read by PyPI -  to be the same as the github published release version, which can lead to confusion. However, the addition of [setuptools-scm](https://pypi.org/project/setuptools-scm/) to the build system dependencies can automate this easily.

I also have another workflow that automatically runs tests, linting, formatting etc. if there is interest.