### PR TITLE
Hotfix fribta demo

### DIFF
--- a/src/rose/basis.py
+++ b/src/rose/basis.py
@@ -98,6 +98,7 @@ class RelativeBasis(Basis):
         theta_train: np.array,
         rho_mesh: np.array,
         n_basis: int,
+        expl_var_ratio_cutoff: float = None,
         phi_0_energy: float = None,
         use_svd: bool = True,
         center: bool = None,
@@ -161,6 +162,14 @@ class RelativeBasis(Basis):
         self.pillars, self.singular_values, self.phi_0 = pre_process_solutions(
             self.solutions, self.phi_0, self.rho_mesh, center, scale, use_svd
         )
+
+        # keeping at min n_basis PC's, find cutoff
+        if expl_var_ratio_cutoff is not None:
+            expl_var = self.singular_values**2 / np.sum(self.singular_values**2)
+            n_basis_svs = np.sum(expl_var > expl_var_ratio_cutoff)
+            self.n_basis = max(n_basis_svs, self.n_basis)
+        else:
+            self.n_basis = n_basis
 
         self.vectors = self.pillars[:, : self.n_basis].copy()
 

--- a/src/rose/basis.py
+++ b/src/rose/basis.py
@@ -331,11 +331,7 @@ def pre_process_solutions(
     subtract_phi0=True,
 ):
     s = rho_mesh
-    if center or scale or subtract_phi0:
-        A = solutions.copy()
-        phi_0 = phi_0.copy()
-    else:
-        A = solutions
+    A = solutions
 
     if scale:
         phi_0 /= np.trapz(np.absolute(phi_0), s)

--- a/src/rose/lagrangelegendersolver.py
+++ b/src/rose/lagrangelegendersolver.py
@@ -68,7 +68,7 @@ class LagrangeRmatrix(SchroedingerEquation):
 
     def get_args_neutral(self, alpha):
         return (
-            alpha[self.param_offset:],
+            alpha[self.param_offset :],
             self.interaction.v_r,
             self.interaction.spin_orbit_term.v_so,
             self.interaction.spin_orbit_term.l_dot_s,
@@ -76,7 +76,7 @@ class LagrangeRmatrix(SchroedingerEquation):
 
     def get_args_coulomb(self, alpha):
         return (
-            alpha[self.param_offset:],
+            alpha[self.param_offset :],
             self.interaction.Z_1 * self.interaction.Z_2,
             self.interaction.coulomb_cutoff(alpha),
             self.interaction.v_r,

--- a/src/rose/lagrangelegendersolver.py
+++ b/src/rose/lagrangelegendersolver.py
@@ -1,6 +1,6 @@
 from .schroedinger import SchroedingerEquation
 from .interaction import Interaction
-from .constants import HBARC
+from .energized_interaction_eim import EnergizedInteractionEIM
 from .utility import potential, potential_plus_coulomb
 from .free_solutions import H_minus, H_plus, H_minus_prime, H_plus_prime
 
@@ -46,6 +46,12 @@ class LagrangeRmatrix(SchroedingerEquation):
         self.channels["Hpp"] = np.array([self.Hpp])
         self.channels["Hmp"] = np.array([self.Hmp])
 
+        # for Energized EIM interactions, E, mu k take up the first 3 spots
+        # in the parameter vector, so we offset to account for that
+        self.param_offset = 0
+        if isinstance(self.interaction, EnergizedInteractionEIM):
+            self.param_offset = 3
+
         if self.interaction.Z_1 * self.interaction.Z_2 > 0:
             self.potential = potential_plus_coulomb
             self.get_args = self.get_args_coulomb
@@ -62,7 +68,7 @@ class LagrangeRmatrix(SchroedingerEquation):
 
     def get_args_neutral(self, alpha):
         return (
-            alpha,
+            alpha[self.param_offset:],
             self.interaction.v_r,
             self.interaction.spin_orbit_term.v_so,
             self.interaction.spin_orbit_term.l_dot_s,
@@ -70,7 +76,7 @@ class LagrangeRmatrix(SchroedingerEquation):
 
     def get_args_coulomb(self, alpha):
         return (
-            alpha,
+            alpha[self.param_offset:],
             self.interaction.Z_1 * self.interaction.Z_2,
             self.interaction.coulomb_cutoff(alpha),
             self.interaction.v_r,


### PR DESCRIPTION
- add `expl_var_ratio_cutoff` as input arg to `RelativeBasis` so the number of reduced basis elems can be chosen on desired fraction of explained variance
- remove unnecessary deep copies from `Basis.__init__`
- fix bug where `LagrangeLegendreSolver` didn't work with `EnergizedInteraction`s