### PR TITLE
Update pyproject.toml to require setuptools>=62.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=61.0", "setuptools_scm[toml]>=6.2"]
+requires = ["setuptools>=62.0", "setuptools_scm[toml]>=6.2"]
 build-backend = "setuptools.build_meta"
 
 [project]


### PR DESCRIPTION
Referencing `pip install` issues in https://github.com/bandframework/bandframework/pull/123